### PR TITLE
set session and csrf cookies

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -2,9 +2,8 @@ class Api::V1::SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:email])
     if user && user.authenticate(params[:password])
-      payload = { user_id: user.id }
-      jwt = JWT.encode payload, ENV['secret'], 'HS256'
-      render json: UserSerializer.new(user), meta: jwt, meta_key: 'jwt'
+      session[:user_id] = user.id
+      render json: UserSerializer.new(user)
     else
       error = 'Email or password invalid. Please try again.'
       render json: ErrorSerializer.new(error), status: :unauthorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+  include ActionController::RequestForgeryProtection
+
+  protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token if Rails.env.test?
+  before_action :set_csrf_cookie if !Rails.env
+
+  private
+
+  def set_csrf_cookie
+    cookies["CSRF-TOKEN"] = form_authenticity_token
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,7 @@ module CommunityShieldServer
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
   end
 end


### PR DESCRIPTION
This PR sets csrf and session cookies for api authentication
adds the cookies middleware back in because the app is an api only app